### PR TITLE
chore(python): switch to native namespaces

### DIFF
--- a/.github/workflows/plone-package-test.yml
+++ b/.github/workflows/plone-package-test.yml
@@ -1,45 +1,19 @@
 name: Tests
 
-on: push
+on:
+  push:
+  pull_request:
+    branches: [ main ]
+  workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        include:
-          - python-version: "3.9"
-            plone-version: "6.0"
-          - python-version: "3.10"
-            plone-version: "6.0"
-    steps:
-      # git checkout
-      - uses: actions/checkout@v2
-
-      # python setup
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v2
-        with:
-          python-version: ${{ matrix.python-version }}
-
-      # python eggs cache
-      - name: Cache eggs
-        uses: actions/cache@v4
-        env:
-          cache-name: cache-eggs
-        with:
-          path: ./eggs
-          key: ${{ runner.os }}-build-${{ env.cache-name }}-${{ matrix.python-version }}-${{ matrix.plone-version }}
-
-      # python install
-      - name: pip install
-        run: pip install -r requirements.txt
-
-      # buildout
-      - name: buildout
-        run: buildout -t 10 -c buildout.cfg
-
-      # test
-      - name: test
-        run: bin/test
+  full-test:
+    uses: IMIO/gha-workflows/.github/workflows/package-full-test.yml@v1
+    secrets:
+      mattermost_webhook_url: ${{ secrets.SMARTWEB_MATTERMOST_WEBHOOK_URL }}
+    with:
+      check_path: |
+        library/policy
+      python_versions: '["3.12", "3.13"]'
+      runner_label: gha-runners-smartweb
+      upload_to_coveralls: true

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,12 @@ Changelog
 2.0.7 (unreleased)
 ------------------
 
+- Switch to PEP 420 native namespace package.
+  [remdub]
+
+- Migrate dev environment to Plone 6.1.5, buildout 5
+  [remdub]
+
 - Migrate to Plone 6.1.4
   [boulch]
 
@@ -50,7 +56,7 @@ Changelog
 2.0.2 (2025-01-14)
 ------------------
 
-- Reinstall collective.behavior.gallery 
+- Reinstall collective.behavior.gallery
   [boulch]
 
 2.0.1 (2024-12-12)

--- a/buildout.cfg
+++ b/buildout.cfg
@@ -1,8 +1,8 @@
 [buildout]
 extends =
-    https://dist.plone.org/release/6.1.4/versions.cfg
-    https://dist.plone.org/release/6.1.4/versions-ecosystem.cfg
-    https://dist.plone.org/release/6.1.4/versions-extra.cfg
+    https://dist.plone.org/release/6.1.5/versions.cfg
+    https://dist.plone.org/release/6.1.5/versions-ecosystem.cfg
+    https://dist.plone.org/release/6.1.5/versions-extra.cfg
     https://raw.githubusercontent.com/IMIO/buildout.library/refs/heads/main/versions.cfg
 
 show-picked-versions = true

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
--r https://dist.plone.org/release/6.1.4/requirements.txt
+-r https://dist.plone.org/release/6.2.1/requirements.txt

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,8 @@
 # -*- coding: utf-8 -*-
 """Installer for the library.policy package."""
 
-from setuptools import find_packages
+from setuptools import find_namespace_packages
 from setuptools import setup
-
 
 long_description = "\n\n".join(
     [
@@ -23,12 +22,11 @@ setup(
     classifiers=[
         "Environment :: Web Environment",
         "Framework :: Plone",
-        "Framework :: Plone :: 6.0",
+        "Framework :: Plone :: 6.1",
         "Framework :: Plone :: Addon",
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Operating System :: OS Independent",
         "License :: OSI Approved :: GNU General Public License v2 (GPLv2)",
     ],
@@ -37,8 +35,7 @@ setup(
     author_email="support@imio.be",
     url="https://pypi.python.org/pypi/library.policy",
     license="GPL version 2",
-    packages=find_packages("src", exclude=["ez_setup"]),
-    namespace_packages=["library"],
+    packages=find_namespace_packages("src", exclude=["ez_setup"]),
     package_dir={"": "src"},
     include_package_data=True,
     zip_safe=False,

--- a/src/library/__init__.py
+++ b/src/library/__init__.py
@@ -1,2 +1,0 @@
-# -*- coding: utf-8 -*-
-__import__("pkg_resources").declare_namespace(__name__)

--- a/src/library/policy/__init__.py
+++ b/src/library/policy/__init__.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 """Init and utils."""
-from zope.i18nmessageid import MessageFactory
 
+from zope.i18nmessageid import MessageFactory
 
 _ = MessageFactory("library.policy")

--- a/src/library/policy/tests/test_setup.py
+++ b/src/library/policy/tests/test_setup.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 """Setup tests for this package."""
+
 from library.policy.testing import LIBRARY_POLICY_INTEGRATION_TESTING  # noqa
 from plone import api
 from plone.app.testing import setRoles


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for newer Python (3.12–3.13) and Plone (6.1.5).
  - Switched to modern native namespace packaging and updated package discovery.

- **Chores**
  - Refreshed CI to use a shared reusable testing workflow, expanded run triggers, and aligned test coverage settings.

- **Documentation**
  - Updated the changelog for the latest migration and release details.

- **Style**
  - Minor formatting cleanup in a few files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->