### PR TITLE
fix: rename library->bibliotheca leftovers

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,13 @@ Changelog
 3.1.2 (unreleased)
 ------------------
 
-- Nothing changed yet.
+- Add upgrade step (1017 -> 1018) to fix ``library.*`` -> ``bibliotheca.*`` rename
+  artifacts left in existing ZODBs: rewrite the stale ``patrimoine`` FTI schema
+  string (fixes a ``RecursionError`` on ``lookupSchema``), purge the orphaned
+  ``ILibraryCoreLayer`` / ``ILibraryPolicyLayer`` browser layers, and register
+  the renamed ``IBibliothecaCoreLayer`` / ``IBibliothecaPolicyLayer`` layers so
+  views/viewlets/tiles bound to them (e.g. the ``existingcontent`` tile) work.
+  [remdub]
 
 
 3.1.1 (2026-07-15)

--- a/src/bibliotheca/policy/profiles/default/metadata.xml
+++ b/src/bibliotheca/policy/profiles/default/metadata.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <metadata>
-  <version>1017</version>
+  <version>1018</version>
   <dependencies>
     <dependency>profile-collective.plausible:default</dependency>
     <dependency>profile-eea.facetednavigation:default</dependency>

--- a/src/bibliotheca/policy/upgrades/configure.zcml
+++ b/src/bibliotheca/policy/upgrades/configure.zcml
@@ -228,4 +228,13 @@
     handler=".upgrades.set_login_modal"
     />
 
+  <genericsetup:upgradeStep
+    source="1017"
+    destination="1018"
+    title="Fix library.* -> bibliotheca.* rename artifacts"
+    description="Rewrite stale FTI schema strings and purge orphaned library.* browser layers left in the ZODB by the package rename"
+    profile="bibliotheca.policy:default"
+    handler=".upgrades.fix_library_rename"
+    />
+
 </configure>

--- a/src/bibliotheca/policy/upgrades/upgrades.py
+++ b/src/bibliotheca/policy/upgrades/upgrades.py
@@ -96,3 +96,73 @@ def install_kimug(context):
 def set_login_modal(context):
     portal = api.portal.get()
     configure_login_modal(portal)
+
+
+def fix_library_rename(context):
+    """Clean up persisted references to the old ``library.*`` package names.
+
+    The add-ons were renamed ``library.*`` -> ``bibliotheca.*``. Sites created
+    before the rename still hold, in the ZODB, references to the now
+    unimportable dotted names, which breaks:
+
+    * the ``patrimoine`` FTI ``schema`` string
+      (``library.core.content.patrimoine.IPatrimoine``) -> RecursionError on
+      ``lookupSchema`` because the fallback dynamic schema lookup loops;
+    * the ``plone.browserlayer`` local utilities registered for
+      ``ILibraryCoreLayer`` / ``ILibraryPolicyLayer`` -> startup warnings.
+
+    It also (re)registers the renamed ``IBibliothecaCoreLayer`` /
+    ``IBibliothecaPolicyLayer`` browser layers, which were never installed in
+    ``library.*``-era sites; without them every view/viewlet/tile bound to
+    those layers (e.g. the ``existingcontent`` standard tile) 404s.
+    """
+    old_prefix = "library."
+    new_prefix = "bibliotheca."
+    portal = api.portal.get()
+    setup_tool = api.portal.get_tool("portal_setup")
+
+    # 1. Rewrite stale FTI schema / model_source strings.
+    ptypes = api.portal.get_tool("portal_types")
+    fixed_types = []
+    for type_id in ptypes.objectIds():
+        fti = ptypes[type_id]
+        for attr in ("schema", "model_source"):
+            value = getattr(fti, attr, None)
+            if value and old_prefix in value:
+                setattr(fti, attr, value.replace(old_prefix, new_prefix))
+                fixed_types.append(type_id)
+
+    # 2. Invalidate the Dexterity schema cache so corrected schemas re-resolve.
+    try:
+        from plone.dexterity.schema import SCHEMA_CACHE
+
+        for type_id in fixed_types:
+            SCHEMA_CACHE.invalidate(type_id)
+        SCHEMA_CACHE.clear()
+    except Exception:  # pragma: no cover - best effort
+        pass
+
+    # 3. Purge the orphaned (Broken) browser-layer utilities.
+    from plone.browserlayer.interfaces import ILocalBrowserLayerType
+
+    sm = portal.getSiteManager()
+    for reg in list(sm.registeredUtilities()):
+        if reg.provided is not ILocalBrowserLayerType:
+            continue
+        iface = reg.component
+        module = getattr(iface, "__module__", "") or ""
+        name = getattr(iface, "__name__", "") or reg.name or ""
+        if module.startswith(old_prefix) or name.startswith("ILibrary"):
+            sm.unregisterUtility(
+                component=iface,
+                provided=ILocalBrowserLayerType,
+                name=reg.name,
+            )
+
+    # 4. Register the renamed browser layers (never installed in library.*-era
+    #    sites). Idempotent: re-importing browserlayer.xml is a no-op if present.
+    for profile in (
+        "profile-bibliotheca.core:default",
+        "profile-bibliotheca.policy:default",
+    ):
+        setup_tool.runImportStepFromProfile(profile, "browserlayer")

--- a/src/bibliotheca/policy/upgrades/upgrades.py
+++ b/src/bibliotheca/policy/upgrades/upgrades.py
@@ -10,7 +10,10 @@ from plone.app.upgrade.utils import loadMigrationProfile
 from Products.CMFCore.utils import getToolByName
 from Products.CMFPlone.utils import get_installer
 
+import logging
 import os
+
+logger = logging.getLogger("bibliotheca.policy")
 
 
 def reload_gs_profile(context):
@@ -140,7 +143,11 @@ def fix_library_rename(context):
             SCHEMA_CACHE.invalidate(type_id)
         SCHEMA_CACHE.clear()
     except Exception:  # pragma: no cover - best effort
-        pass
+        logger.exception(
+            "fix_library_rename: failed to invalidate the Dexterity "
+            "schema cache for types %r; continuing upgrade.",
+            fixed_types,
+        )
 
     # 3. Purge the orphaned (Broken) browser-layer utilities.
     from plone.browserlayer.interfaces import ILocalBrowserLayerType


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an upgrade issue caused by the `library.*` → `bibliotheca.*` rename, including stale content-type schema/model references that could lead to recursion errors.
  * Cleaned up leftover browser-layer artifacts from existing installations and restored compatibility so tiles/viewlets continue working.

* **Upgrade Improvements**
  * Added an automatic migration step that updates existing saved references, removes orphaned layers, and re-registers renamed layers in the upgrade path.
  * Improved release documentation by replacing placeholder text with detailed remediation instructions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->